### PR TITLE
Fixed "types" value: Correct path to index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "files": [
     "dist"
   ],
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "moduleFileExtensions": [
     "ts",
     "tsx",


### PR DESCRIPTION
The incorrect path causes, that TypeScript is not able to find the .d.ts definition file and hence will interpret all imports from "curve-interpolator" package as any.